### PR TITLE
Fix one more instance of ".av1f" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ I pronounce it *AY-peg*, which rhymes with JPEG.
 It isn't quite ready for primetime now, so I'd avoid it unless you're just curious about testing
 basic AV1 image compression. It currently encodes all images in YUV444 12-bit (with an adjustable
 1-100 quality level), and doesn't support alpha. If you're discovering this library right now and a
-turnkey, feature complete `.av1f` library out there exists since I wrote this README, you should
+turnkey, feature complete AVIF library out there exists since I wrote this README, you should
 probably use that instead.
 
 # Build Notes


### PR DESCRIPTION
Missed one in my initial PR.