### PR TITLE
Add continuous integration with AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: c
 dist: xenial
 
+compiler:
+  - clang
+  - gcc
+
 install:
     # install Nasm
     - wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz
@@ -11,7 +15,9 @@ install:
     - sudo make install
     - nasm --version
     - cd ..
+    - mkdir .build && cd .build
 
 script:
-    - mkdir .build && cd .build
-    - cmake .. && make && sudo make install
+    - cmake ..
+    - make
+    - sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: c
+dist: xenial
+
+install:
+    # install Nasm
+    - wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz
+    - tar -xvf nasm-2.14.02.tar.xz
+    - cd nasm-2.14.02
+    - ./configure
+    - make
+    - sudo make install
+    - nasm --version
+    - cd ..
+
+script:
+    - mkdir .build && cd .build
+    - cmake .. && make && sudo make install

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# APG: AV1 Portable Graphics
+# APG: AV1 Portable Graphics [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/joedrago/apg?branch=master&svg=true)](https://ci.appveyor.com/project/joedrago/apg/history)
+
 
 APG is a new image format intended to be a stopgap, lightweight alternative to [AVIF](https://aomediacodec.github.io/av1-avif/) until a
 proper/stable/mature/turnkey AVIF library with BMFF and alpha channel support exists. It is a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,5 @@ build:
   project: aom_build/apg.sln
 
 artifacts:
-    - path: bin\Release\*.*
+    - path: aom_build\bin\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-configuration: Release
+configuration: Release|x64
 
 install:
     - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ configuration: Release
 install:
     - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
     - 7z e -y nasm.zip
+    - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
     - mkdir aom_build & cd aom_build
     - cmake ..
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,7 @@ build:
   project: aom_build/apg.sln
 
 artifacts:
-    - path: \**\Release\*.*
+    - path: aom_build\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)
+    - path: aom_build\ext\aom\Release\aom.lib
+      name: libaom

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 image: Visual Studio 2017
-configuration: Release|x64
+configuration: Release
 
 install:
     - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,5 +12,5 @@ build:
   project: aom_build/apg.sln
 
 artifacts:
-    - path: aom_build\bin\Release\*.*
+    - path: \**\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
     - 7z e -y nasm.zip
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
     - mkdir aom_build & cd aom_build
-    - cmake ..
+    - cmake .. -A x64
 
 build:
   project: aom_build/apg.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
     - cmake ..
 
 build:
-  project: apg.sln
+  project: aom_build/apg.sln
 
 artifacts:
     - path: bin\Release\*.*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+image: Visual Studio 2017
+configuration: Release
+
+install:
+    - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
+    - 7z e -y nasm.zip
+    - cmake .
+
+build:
+  project: apg.sln
+
+artifacts:
+    - path: bin\Release\*.*
+      name: $(APPVEYOR_PROJECT_NAME)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,8 @@ configuration: Release
 install:
     - appveyor DownloadFile https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/win64/nasm-2.14.02-win64.zip -FileName nasm.zip
     - 7z e -y nasm.zip
-    - cmake .
+    - mkdir aom_build & cd aom_build
+    - cmake ..
 
 build:
   project: apg.sln


### PR DESCRIPTION
Builds apg with Visual Studio 15 2017 on 64-bit Windows. AppVeyor needs to be activated on [ci.appveyor.com](https://ci.appveyor.com/project/joedrago/apg) or on the [GitHub marketplace](https://github.com/marketplace/appveyor).

Publishes apg.lib and aom.lib artifacts to AppVeyor. [Example builds](https://ci.appveyor.com/project/EwoutH/apg/history).